### PR TITLE
BIDSto3col: events.tsv without "event type" column 

### DIFF
--- a/BIDSto3col/README.md
+++ b/BIDSto3col/README.md
@@ -2,33 +2,30 @@
 Contributed by Tom Nichols. See attached for BIDSto3col.sh.  From the help...
 
 ```
-  Usage: BIDSto3col.sh \[options\] BidsTSV OutBase
-  
-  Reads BIDS events.tsv and then creates 3 column event files, one per event type, 
-  using the basename OutBase.  By default, all event types are used, and the height 
-  value (3rd column) is 1.0.
-  
-  Options
-    -e EventName   Instead of all event types, only use the given event type.
-    -h ColName     Instead of using 1.0, get heigh value from column ColName.
+Usage: BIDSto3col.sh [options] BidsTSV OutBase 
+
+Reads BidsTSV and then creates 3 column event files, one per event type, 
+using the basename OutBase.  By default, all event types are used, and the 
+height value (3rd column) is 1.0.
+
+Options
+  -e EventName   Instead of all event types, only use the given event type.
+  -s EventName   Treat all rows as a single event type; specify the EventName
+                 to be used when creating the file name for the 3 column file.
+  -h ColName     Instead of using 1.0, get height value from given column.
+  -N             By default, when creating 3 column files any spaces in the 
+                 event name are replaced with "_"; use this option to
+                 prevent this replacement.
 ```
 
-Here's a demo...
+Examples of usage:
 
 ```
   $ BIDSto3col.sh ds001/sub-13/func/sub-13_task-balloonanalogrisktask_run-01_events.tsv /tmp/duh
-  Creating '/tmp/duh_cash_demean.txt'...
-  Creating '/tmp/duh_cash_fixed_real_RT.txt'...
-  Creating '/tmp/duh_control_pumps_demean.txt'...
-  Creating '/tmp/duh_control_pumps_fixed_real_RT.txt'...
-  Creating '/tmp/duh_explode_demean.txt'...
-  Creating '/tmp/duh_pumps_demean.txt'...
-  Creating '/tmp/duh_pumps_fixed_real_RT.txt'...
   $ BIDSto3col.sh -e cash_demean ds001/sub-13/func/sub-13_task-balloonanalogrisktask_run-01_events.tsv /tmp/duh
-  Creating '/tmp/duh_cash_deman.txt'...
   $ BIDSto3col.sh -e cash_demean -h explode_demean ds001/sub-13/func/sub-13_task-balloonanalogrisktask_run-01_events.tsv /tmp/duh
-  Creating '/tmp/duh_cash_demean.txt'...
-  	WARNING: Event 'cash_demean' has non-numeric heights from 'explode_demean'
+  $ BIDSto3col.sh -s Event sub-01_task-mixedgamblestask_run-01_events.tsv OUT
+  $ BIDSto3col.sh -s Ev -h "parametric loss" sub-01_task-mixedgamblestask_run-01_events.tsv OUT
 ```
 
 Note that it checks for non-numeric heights (and missing event names and/or column names).


### PR DESCRIPTION
This update to `BIDSto3col.sh`, implemented by @nicholst, allow to deal with parametric modulation (e.g. as in OpenfMRI ds005's sub-01_task-mixedgamblestask_run-01_events.tsv file).

Usage is:

```
BIDSto3col.sh -s Event sub-01_task-mixedgamblestask_run-01_events.tsv OUT
```

to get a common (single) Event file (`OUT_Event.txt`).  

To get the "parametric loss" as a parametric modulation, usage is:

```
BIDSto3col.sh -s Ev -h "parametric loss" sub-01_task-mixedgamblestask_run-01_events.tsv OUT
```
