### PR TITLE
Options change

### DIFF
--- a/BIDSto3col/BIDSto3col.sh
+++ b/BIDSto3col/BIDSto3col.sh
@@ -9,6 +9,9 @@
 # Extension to give created 3 column files
 ThreeColExt="txt"
 
+# Replace slashes in event names with this character.
+SlashReplace=""
+
 # To avoid headaches with spaces in filenames, replace spaces in event names 
 # with this character.
 SpaceReplace="_"
@@ -28,7 +31,6 @@ AwkHd='{sub(/\r$/,"")};'
 shopt -s nullglob # No-match globbing expands to null
 Tmp=/tmp/`basename $0`-${$}-
 trap CleanUp INT
-
 ###############################################################################
 #
 # Functions
@@ -213,6 +215,8 @@ for E in "${EventNms[@]}" ; do
     if [ "$NoAppend" = 1 ] ; then
 	App=""
     else
+	E="$(echo "$E" | sed 's@/@'$SlashReplace'@g')"
+
 	if [ "$NoSpaceRepl" = 1 ] ; then
 	    App="_${E}"
 	else

--- a/BIDSto3col/BIDSto3col.sh
+++ b/BIDSto3col/BIDSto3col.sh
@@ -51,9 +51,7 @@ Options
   -s             Even if "$TypeNm" column is found, ignore and process
                  all rows as a single event type.
   -e EventName   Instead of all event types, only use the given event
-                 type. 
-  -E EventName   Same as -e, except output file name does not have
-                 EventName appended.
+                 type (no event name appended to OutBase).. 
   -h HtColName   Instead of using 1.0, get height value from given
                  column; two files are written, the unmodulated (with
                  1.0 in 3rd column) and the modulated one, having a
@@ -91,11 +89,6 @@ while (( $# > 1 )) ; do
             shift
             ;;
         "-e")
-            shift
-            EventNm="$1"
-            shift
-            ;;
-        "-E")
             shift
             EventNm="$1"
 	    NoAppend=1

--- a/BIDSto3col/README.md
+++ b/BIDSto3col/README.md
@@ -5,22 +5,18 @@ Contributed by Tom Nichols. See attached for BIDSto3col.sh.  From the help...
 Usage: BIDSto3col.sh [options] BidsTSV OutBase 
 
 Reads BidsTSV and then creates 3 column event files, one per event
-type; files are named as basename OutBase and appended with the event
-name. By default, all event types are used, and the height value (3rd
-column) is 1.0.  
-
-Assumes the presense of a (BIDS optional) "trial_type" column.  Use -t 
-option to set a different name for this column, or -s to ignore trial
-type. 
+type if a "trial_type" column is found.  Files are named as OutBase
+and, if "trial_type" is present, appended with the event name. 
+By default, all rows and event types are used, and the height value
+(3rd column) is 1.0.   
 
 Options
+  -s             Even if "trial_type" column is found, ignore and process
+                 all rows as a single event type.
   -e EventName   Instead of all event types, only use the given event
                  type. 
-  -s EventName   Treat all rows as a single event type; specify the
-                 EventName to be used when creating the file name for
-                 the 3 column file. 
-  -n             When only one event type (e.g. when -e or -s option
-                 used) do not append the event name to OutBase. 
+  -E EventName   Same as -e, except output file name does not have
+                 EventName appended.
   -h HtColName   Instead of using 1.0, get height value from given
                  column; two files are written, the unmodulated (with
                  1.0 in 3rd column) and the modulated one, having a
@@ -30,8 +26,8 @@ Options
   -t TypeColName Instead of getting trial type from "trial_type"
                  column, use this column.
   -N             By default, when creating 3 column files any spaces
-                 in the event name are replaced with "_";
-                 use this option to prevent this replacement.
+                 in the event name are replaced with "$SpaceReplace";
+                 use this option to suppress this replacement.
 ```
 
 Here's a demo...


### PR DESCRIPTION
Revised BIDSto3col.sh to work without options when trial_type is missing.  I did this because trial_type is not mandatory (and simply doesn't make sense for some experiments), and the script should work gracefully (i.e. optionless) when no trial_type column is present.

Changes comprise:
- If trial_type is missing, all rows are processed.  Output file is just OutBase (nothing appended).
- -s option no longer takes an event type name... if you're specifying a single event, just set OutBase accordingly.
- -e option to select a single event type is left as is, but...
- Added -E option to select a single event type _without_ appending event name to OutBase.

@AlexBowring, this will affect your usage... is this all OK?

@AlexBowring, @cmaumet - It seems like having both -e and -E option is overkill.  Should I just have one (e.g. -e) that behaves like -s (i.e. doesn't append the event name to OutBase)?
